### PR TITLE
Add aapt2 option for apktool

### DIFF
--- a/apkutil/cli.py
+++ b/apkutil/cli.py
@@ -36,7 +36,7 @@ def cmd_todebuggable(args):
         apk_path = dir_name + ".patched.apk"
 
     try:
-        util.build(dir_name, apk_path)
+        util.build(dir_name, apk_path, aapt2=args.aapt2)
     except Exception as e:
         print(e)
         print(Fore.RED + 'Failed')
@@ -76,7 +76,7 @@ def cmd_build(args):
     if args.output is None:
         apk_path = args.dir_name + ".patched.apk"
     try:
-        util.build(args.dir_name, apk_path)
+        util.build(args.dir_name, apk_path, aapt2=args.aapt2)
     except Exception as e:
         print(e)
         print(Fore.RED + 'Failed')
@@ -127,6 +127,8 @@ def cmd_screenshot(args):
 def main():
     colorama.init(autoreset=True)
     parser = argparse.ArgumentParser(description='useful utility for android security testing')
+    parser.add_argument('--use-aapt2', '-2', action='store_true',
+        dest='aapt2', help='Use the aapt2 binary instead of aapt as part of the apktool processing.')
     subparsers = parser.add_subparsers()
 
     parser_todebuggable = subparsers.add_parser('debuggable', aliases=['debug', 'dg'], help='')

--- a/apkutil/util.py
+++ b/apkutil/util.py
@@ -30,17 +30,29 @@ def decode(apk_path):
         print('Please install apktool')
 
 
-def build(dir_name, apk_path):
+def build(dir_name, apk_path, aapt2=False):
     apktool_cmd = ['apktool']
     apktool_cmd.extend(['b', dir_name])
     apktool_cmd.extend(['-o', apk_path])
+
+    if aapt2:
+        apktool_cmd.extend(['--use-aapt2'])
+    
     try:
         proc = subprocess.Popen(apktool_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         outs, errs = proc.communicate()
+
+        is_built = False
+
         if (outs is not None) and (len(outs) != 0):
-            print(outs.decode('ascii'))
+            outs = outs.decode('ascii')
+
+            if "I: Built apk..." in outs:
+                is_built = True
+
+            print(outs)
         
-        if (errs is not None) and (len(errs) != 0):
+        if (errs is not None) and (len(errs) != 0) and not is_built:
             errs = errs.decode('ascii')
             raise Exception(errs)
 


### PR DESCRIPTION
Fix apktool error for new version apk by adding aapt2 option for apktool.