### PR TITLE
fix: Invalid cross-device link

### DIFF
--- a/apkutil/util.py
+++ b/apkutil/util.py
@@ -6,6 +6,7 @@ import glob
 import json
 import os
 import subprocess
+from shutil import move
 from colorama import Fore
 
 
@@ -82,7 +83,7 @@ def align(apk_path):
             errs = errs.decode('ascii')
             raise Exception(errs)
 
-        os.replace('/tmp/apkutil_tmp.aligned.apk', apk_path)
+        move('/tmp/apkutil_tmp.aligned.apk', apk_path)
     except (IndexError, FileNotFoundError) as e:
         print('zipalign not found.')
         print('Please install Android SDK Build Tools.')


### PR DESCRIPTION
When running `apkutil b app-release -o updated.apk` and got the following error.
  
```
Aligning APK by zipalign...
[Errno 18] Invalid cross-device link: '/tmp/apkutil_tmp.aligned.apk' -> 'updated.apk'
Failed
```

Googling a little bit, I found that just changing the `os.rename` to `shutil.move` solves the issue. It seems a smarter way to move files in different OSes (as far I can tell).

Best Regards 