### PR TITLE
fix: add missing aapt2 argument parser for "all" subcommand

### DIFF
--- a/apkutil/cli.py
+++ b/apkutil/cli.py
@@ -277,6 +277,8 @@ def main():
     parser_all = subparsers.add_parser('all', help='set debuggable & networkSecurityConfig, build & sign APK')
     parser_all.add_argument('apk_path', help='')
     parser_all.add_argument('--output', '-o')
+    parser_all.add_argument('-2', '--aapt2', '--use-aapt2', action='store_true',
+        dest='aapt2', help='use the aapt2 binary instead of aapt as part of the apktool processing.')
     parser_all.set_defaults(handler=cmd_all)
 
     parser_decode = subparsers.add_parser('decode', aliases=['d'], help='decode APK')


### PR DESCRIPTION
`args.aapt2` is being used in line 148 in `cmd_all` function; however, it is not declared in the argument parser.

https://github.com/aktsk/apkutil/blob/fa68d388a3a32389c9d6108c909172f32e604d2e/apkutil/cli.py#L117-L149

This causes the `all` subcommand to be unusable as shown in the following example:
```
$ apkutil all UnCrackable-Level1.apk
Decoding APK by Apktool...
I: Using Apktool 2.6.0 on UnCrackable-Level1.apk
I: Loading resource table...
I: Decoding AndroidManifest.xml with resources...
I: Loading resource table from file: /tmp/1.apk
I: Regular manifest package...
I: Decoding file-resources...
I: Decoding values */* XMLs...
I: Baksmaling classes.dex...
I: Copying assets and libs...
I: Copying unknown files...
I: Copying original files...

Potentially Sensitive Files:
None

Checking AndroidManifest.xml...
Package name:
owasp.mstg.uncrackable1

Permission:

Debuggable:
False

AllowBackup:
True

Custom schemas:
None

Set debuggable attribute to true in AndroidManifest!

Set networkSecurityConfig attribute to true in AndroidManifest!

Building APK by Apktool...
'Namespace' object has no attribute 'aapt2'
Failed
```

This PR resolves this by adding the parser for the required argument.